### PR TITLE
Specify a commit for the libreoffice buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/heroku/heroku-buildpack-java.git#v32
-https://github.com/rishihahs/heroku-buildpack-libreoffice
+https://github.com/rishihahs/heroku-buildpack-libreoffice#41732b8
 https://github.com/heroku/heroku-buildpack-ruby.git


### PR DESCRIPTION
This may be a temporary workaround for an issue recently introduced in the build packs for libreoffice.  A recent update causes push to heroku to fail.  This fix uses a specific commit before the issue was introduced.

https://github.com/rishihahs/heroku-buildpack-libreoffice/issues/4
