### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.1.10
+
+RUN apt update
+RUN apt -y install libreoffice
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+CMD ["bash", "-c", "bundle exec rackup -p $PORT config.ru"]

--- a/README.md
+++ b/README.md
@@ -47,3 +47,10 @@ If you're collaborating on text with someone:
 
 1. `bundle exec rackup`
 2. Follow the [ngrok documentation](https://developer.github.com/webhooks/configuring/#using-ngrok) to forward requests to your computer if you don't want to set up a development server
+
+## Running on Docker
+
+1. Build the docker image `docker build -t <username>/word-diff:<tag> .`
+2. Run the image in a container with the required environment variables
+   - `docker run -d -p 3001:3001 -e PORT='3001' -e GITHUB_TOKEN='<token>' -e SECRET_TOKEN='<token>' --name word-diff <username>/word-diff:<tag>`
+   - make sure to replace the values with your information


### PR DESCRIPTION
Hello!

I found out about this tool just yesterday and I wanted to deploy it on my Kubernetes cluster. Therefore, I needed to Dockerize it so I forked the repo and added this Docker file. After getting it to work correctly I decided to share the code so someone else could have an easier time running word_diff on Docker.

## Additional Thoughts
- The docker image produced by this Dockerfile is not optimized to be the smallest size it could be. That might be something to consider for the future since the image is pretty large.

-----
[View rendered README.md](https://github.com/deznorth/word_diff/blob/master/README.md)